### PR TITLE
Potential fix for code scanning alert no. 72: Incorrect conversion between integer types

### DIFF
--- a/vlib/sync/bench/channel_bench_go.go
+++ b/vlib/sync/bench/channel_bench_go.go
@@ -3,6 +3,7 @@ package main
 import "fmt"
 import "log"
 import "os"
+import "math"
 import "time"
 import "strconv"
 
@@ -51,6 +52,9 @@ func main() {
 		n := no / (nsend - i)
 		end := no
 		no -= n
+		if end < math.MinInt32 || end > math.MaxInt32 {
+			log.Fatalf("value out of range for int32: %d", end)
+		}
 		go do_send(ch, int32(no), int32(end))
 	}
 	assert_eq(int64(no), 0)	


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/72](https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/72)

To fix the issue, we need to ensure that the value of `end` is within the valid range of `int32` before performing the conversion. This can be achieved by adding bounds checks for `end` against the minimum and maximum values of `int32` (defined in the `math` package as `math.MinInt32` and `math.MaxInt32`). If the value is out of bounds, the program should handle the error gracefully, such as by logging an error message and exiting.

The changes will be made in the `main` function, specifically around the calculation and conversion of `end` on line 54.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
