### PR TITLE
Potential fix for code scanning alert no. 75: Uncontrolled data used in path expression

### DIFF
--- a/examples/js_dom_draw_benchmark_chart/typescript_vanilla_typeorm/src/server.js
+++ b/examples/js_dom_draw_benchmark_chart/typescript_vanilla_typeorm/src/server.js
@@ -11,7 +11,13 @@ const port = 3000;
 const reqListener = async (req, res) => {
   console.log(`[route] - (${req.method}) ${req.url}`);
 
-  var filePath = "." + req.url;
+  const ROOT = path.resolve(__dirname, 'public');
+  var filePath = path.resolve(ROOT, '.' + req.url);
+  if (!filePath.startsWith(ROOT)) {
+    res.writeHead(403);
+    res.end("Access denied");
+    return;
+  }
   // if (filePath == './') {
   //     filePath = './index.html';
   // }


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/75](https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/75)

To fix the problem, we need to ensure that the `filePath` is properly validated and normalized before it is used. This can be achieved by:
1. Normalizing the `filePath` using `path.resolve` to remove any ".." segments.
2. Ensuring that the normalized `filePath` is within a predefined root directory.

We will:
- Define a root directory.
- Normalize the `filePath` using `path.resolve`.
- Check that the normalized `filePath` starts with the root directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
