### PR TITLE
Potential fix for code scanning alert no. 70: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -1,5 +1,8 @@
 name: CI Windows
 
+permissions:
+  contents: read
+
 on:
   push:
     paths-ignore:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/70](https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/70)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions`. Based on the provided workflow, the jobs primarily involve building, testing, and verifying code, which typically only require `contents: read`. We will set this as the minimal permission.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
