### PR TITLE
Potential fix for code scanning alert no. 77: Client-side cross-site scripting

### DIFF
--- a/examples/veb/websocket/assets/client.js
+++ b/examples/veb/websocket/assets/client.js
@@ -16,7 +16,9 @@ function start_reconnecting_socket(timeout, target) {
    var nsocket = new WebSocket(target);
    nsocket.addEventListener('open', (event) => {   console.log('Connected to WS server'); set_status('connected'); });
    nsocket.addEventListener('message', (event) => {
-      messageList.innerHTML += `<li>received: <b>${event.data}</b></li>`;
+      const listItem = document.createElement('li');
+      listItem.textContent = `received: ${event.data}`;
+      messageList.appendChild(listItem);
       set_status('received message');
    });
    nsocket.addEventListener('close', (event) => {  


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/77](https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/77)

To fix the issue, we need to sanitize the untrusted input (`event.data`) before inserting it into the DOM. The best approach is to use a method that avoids directly setting `innerHTML` with untrusted data. Instead, we can create a new DOM element (e.g., a `<li>` element) and set its text content to the sanitized value. This ensures that any potentially malicious input is treated as plain text rather than executable HTML/JavaScript.

Changes to make:
1. Replace the use of `innerHTML` on line 19 with a safer alternative that uses `textContent` for the untrusted part of the input.
2. Create a new `<li>` element, set its text content to the sanitized value, and append it to the `messageList`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
