### PR TITLE
Potential fix for code scanning alert no. 69: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/workflow_lint.yml
+++ b/.github/workflows/workflow_lint.yml
@@ -6,6 +6,9 @@ name: Workflow Lint
 ## If you already have `prettier` installed, to run it locally,
 ## just run: `npx prettier --check **.yml` .
 
+permissions:
+  contents: read
+
 on:
   push:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/69](https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/69)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. Since the workflow only verifies YAML formatting using Prettier, it does not require any write permissions. We will set the permissions to `contents: read`, which is the minimal permission required for most workflows. This ensures that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
