### PR TITLE
Potential fix for code scanning alert no. 68: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/websockets_ci.yml
+++ b/.github/workflows/websockets_ci.yml
@@ -1,5 +1,8 @@
 name: Websockets CI
 
+permissions:
+  contents: read
+
 on:
   push:
     paths-ignore:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/68](https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/68)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow primarily involves running tests, installing dependencies, and uploading artifacts, it likely only requires `contents: read` permissions. This minimal permission level ensures that the workflow can access the repository's contents without granting unnecessary write permissions.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs. If specific jobs require additional permissions, they can override the root-level permissions with their own `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
