### PR TITLE
Potential fix for code scanning alert no. 67: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/wasm_backend_ci.yml
+++ b/.github/workflows/wasm_backend_ci.yml
@@ -1,4 +1,6 @@
 name: wasm backend CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/67](https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/67)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly set the permissions for the `GITHUB_TOKEN` to `contents: read`, which is sufficient for the operations performed in this workflow. This change ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
