### PR TITLE
Potential fix for code scanning alert no. 65: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/vup_works.yml
+++ b/.github/workflows/vup_works.yml
@@ -1,5 +1,8 @@
 name: Upgrading from a previous release with v up works
 
+permissions:
+  contents: read
+
 on:
   push:
     paths-ignore:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/65](https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/65)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required. Based on the workflow's actions, the `contents: read` permission is sufficient, as the workflow only needs to read repository contents (e.g., for checking out the code and downloading files). This change will ensure that the workflow does not inadvertently gain unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
