### PR TITLE
Potential fix for code scanning alert no. 64: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/vsl_and_vtl_compile_ci.yml
+++ b/.github/workflows/vsl_and_vtl_compile_ci.yml
@@ -1,5 +1,8 @@
 name: VSL and VTL
 
+permissions:
+  contents: read
+
 on:
   push:
     paths-ignore:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/64](https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/64)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Based on the provided workflow, it primarily involves checking out the repository and running tests, so `contents: read` should suffice. If additional permissions are required for specific actions, they can be added later.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
