### PR TITLE
Potential fix for code scanning alert no. 63: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/vpm_ci.yml
+++ b/.github/workflows/vpm_ci.yml
@@ -10,6 +10,9 @@ on:
       - '**/vpm_ci.yml'
       - '**/cmd/tools/vpm/**'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/63](https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/63)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow only performs actions like checking out the repository, caching files, and running tests, it likely only requires `contents: read` permissions. We will add this block at the workflow level to apply it to all jobs (`setup` and `test`) unless overridden by a job-specific `permissions` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
