### PR TITLE
Potential fix for code scanning alert no. 60: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/vinix_ci.yml
+++ b/.github/workflows/vinix_ci.yml
@@ -1,4 +1,6 @@
 name: Build Vinix
+permissions:
+  contents: read
 
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/60](https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/60)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the permissions for the `GITHUB_TOKEN`. Based on the workflow's tasks, it seems that only `contents: read` is required, as the workflow primarily involves building and installing dependencies without modifying repository contents or interacting with other GitHub features.

The `permissions` block should be added at the top level of the workflow, just below the `name` field, to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
