### PR TITLE
Potential fix for code scanning alert no. 58: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/vab_ci.yml
+++ b/.github/workflows/vab_ci.yml
@@ -1,4 +1,6 @@
 name: vab CI
+permissions:
+  contents: read
 
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/58](https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/58)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific permissions. Based on the actions performed in the workflow, such as checking out the repository and running commands, the minimal required permission is `contents: read`. This ensures that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
