### PR TITLE
Potential fix for code scanning alert no. 57: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tools_ci.yml
+++ b/.github/workflows/tools_ci.yml
@@ -1,4 +1,6 @@
 name: Tools CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/57](https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/57)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly set `contents: read`, which is sufficient for the tasks performed in this workflow. This ensures that the workflow does not inadvertently gain unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
