### PR TITLE
Potential fix for code scanning alert no. 54: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sanitized_ci.yml
+++ b/.github/workflows/sanitized_ci.yml
@@ -1,4 +1,6 @@
 name: Sanitized CI
+permissions:
+  contents: read
 
 ## Running these jobs is slow (over ~1 hour, sometimes even 2)
 ## so we run them only when there is a chance that the generated


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/54](https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/54)

To fix the issue, we will add a `permissions` block at the root level of the workflow to apply minimal permissions to all jobs. Since the workflow primarily involves building, testing, and installing dependencies, it likely only requires `contents: read`. If any job requires additional permissions, we can override the root-level permissions by adding a specific `permissions` block for that job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
