### PR TITLE
Potential fix for code scanning alert no. 49: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/time_ci.yml
+++ b/.github/workflows/time_ci.yml
@@ -1,5 +1,8 @@
 name: Time CI
 
+permissions:
+  contents: read
+
 on:
   push:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/49](https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/49)

To fix the issue, we will add a `permissions` block at the root level of the workflow. Since the workflow only needs to read the repository contents (e.g., for checking out the code), we will set `contents: read`. This ensures that the `GITHUB_TOKEN` has the least privilege required to execute the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
