### PR TITLE
Potential fix for code scanning alert no. 45: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/symlink_ci.yml
+++ b/.github/workflows/symlink_ci.yml
@@ -1,5 +1,8 @@
 name: Symlink CI
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/45](https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/45)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly set the permissions to the minimum required for the workflow to function correctly. Based on the workflow's operations, it appears that only `contents: read` is necessary, as the workflow primarily checks out the repository and runs tests without modifying repository contents or performing other write operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
