### PR TITLE
Potential fix for code scanning alert no. 41: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/toml_ci.yml
+++ b/.github/workflows/toml_ci.yml
@@ -1,4 +1,6 @@
 name: toml CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/41](https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/41)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the minimal permissions required for the workflow to function. Based on the workflow's operations, it primarily requires `contents: read` to access repository files. No write permissions are necessary.

The `permissions` block will be added immediately after the `name` field in the workflow file. This ensures that the permissions apply to all jobs in the workflow unless overridden by job-specific `permissions` blocks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
