### PR TITLE
Potential fix for code scanning alert no. 39: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sdl_ci.yml
+++ b/.github/workflows/sdl_ci.yml
@@ -1,4 +1,6 @@
 name: sdl CI
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/39](https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/39)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Based on the operations in the workflow, the `contents: read` permission is sufficient, as the workflow only needs to read repository contents and does not perform any write operations.

The `permissions` block will be added immediately after the `name` field in the workflow file to apply the permissions globally to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
