### PR TITLE
Potential fix for code scanning alert no. 38: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/prebuilt.yml
+++ b/.github/workflows/prebuilt.yml
@@ -5,6 +5,9 @@ on:
   release:
     types: [edited, published]
 
+permissions:
+  contents: read
+
 jobs:
   ubuntu:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/38](https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/38)

To fix the issue, we will add a `permissions` block at the workflow level to apply to all jobs. Since the workflow only downloads and tests binaries, it likely only requires `contents: read` permissions. This ensures the workflow adheres to the principle of least privilege while maintaining its functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
