### PR TITLE
Potential fix for code scanning alert no. 33: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/other_ci.yml
+++ b/.github/workflows/other_ci.yml
@@ -1,4 +1,6 @@
 name: Other CI
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/33](https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/33)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required. Based on the workflow's steps, the `contents: read` permission is sufficient for most jobs, as they primarily involve checking out code and running commands. If any job requires additional permissions, they can be specified at the job level.

The `permissions` block will be added near the top of the workflow file, immediately after the `name` field, to apply to all jobs by default.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
