### PR TITLE
Potential fix for code scanning alert no. 37: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/puzzle_vibes_ci.yml
+++ b/.github/workflows/puzzle_vibes_ci.yml
@@ -1,5 +1,8 @@
 name: Shy and PV CI
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/37](https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/37)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the minimal permissions required for the workflow to function. Based on the provided steps, the workflow does not appear to require any write permissions, so we will set `contents: read` as the default permission. This ensures that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
