### PR TITLE
Potential fix for code scanning alert no. 31: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/paths_ci.yml
+++ b/.github/workflows/paths_ci.yml
@@ -1,5 +1,8 @@
 name: Path Testing CI
 
+permissions:
+  contents: read
+
 on:
   push:
     paths-ignore:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/31](https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/31)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions`. Based on the workflow's operations, the minimal required permission is `contents: read`, as the workflow only needs to read repository contents for building and testing.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
