### PR TITLE
Potential fix for code scanning alert no. 29: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/periodic_ci.yml
+++ b/.github/workflows/periodic_ci.yml
@@ -10,6 +10,9 @@ on:
     paths:
       - '**/periodic_ci.yml'
 
+permissions:
+  contents: read
+
 jobs:
   network:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/29](https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/29)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the minimal permissions required for the workflow to function. Since the workflow only checks out code and runs build and test commands, it likely only needs `contents: read` permissions. This ensures that the workflow cannot perform any unintended write operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
