### PR TITLE
Potential fix for code scanning alert no. 28: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -1,5 +1,8 @@
 name: CI Linux
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/28](https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/28)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions` blocks. Based on the tasks performed in the workflow, the minimal required permission is `contents: read`. This change ensures that the `GITHUB_TOKEN` has only the necessary permissions, reducing the risk of misuse.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
