### PR TITLE
Potential fix for code scanning alert no. 23: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/native_backend_ci.yml
+++ b/.github/workflows/native_backend_ci.yml
@@ -1,5 +1,8 @@
 name: native backend CI
 
+permissions:
+  contents: read
+
 on:
   push:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/23](https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/23)

To fix the issue, add a `permissions` block at the root level of the workflow file. Since the workflow only involves checking out the repository and running tests, it likely only requires `contents: read` permissions. This change will explicitly limit the permissions of the `GITHUB_TOKEN` to the minimum necessary for the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
