### PR TITLE
Potential fix for code scanning alert no. 20: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/module_docs_lint.yml
+++ b/.github/workflows/module_docs_lint.yml
@@ -1,4 +1,6 @@
 name: Code CI vlib modules
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/20](https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/20)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly limit the permissions of the `GITHUB_TOKEN`. Since this workflow only performs linting and does not require write access, we will set `permissions` to `contents: read`. This ensures the workflow has the minimal permissions necessary to function correctly.

The `permissions` block will be added at the root level of the workflow, just below the `name` field, so it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
