### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/module_docs_ci.yml
+++ b/.github/workflows/module_docs_ci.yml
@@ -1,5 +1,8 @@
 name: vlib modules CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/19](https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/19)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required. Based on the workflow's steps:
- Most steps (e.g., building, testing, and generating documentation) only require `contents: read`.
- The deployment step does not rely on `GITHUB_TOKEN` for write access, as it uses a separate `VERCEL_TOKEN`. Therefore, no additional permissions are needed.

The `permissions` block will be added at the root of the workflow to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
