### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hub_docker_ci.yml
+++ b/.github/workflows/hub_docker_ci.yml
@@ -1,5 +1,8 @@
 name: hub_docker_ci
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/15](https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/15)

To fix the issue, we will add a `permissions` block at the workflow level (root) to limit the permissions of the `GITHUB_TOKEN`. Based on the workflow's operations, it primarily interacts with Docker Hub and does not require write access to the repository. Therefore, we will set `contents: read` as the minimal permission. If additional permissions are required in the future, they can be added explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
