### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gen_vc_ci.yml
+++ b/.github/workflows/gen_vc_ci.yml
@@ -1,5 +1,8 @@
 name: VC gen
 
+permissions:
+  contents: write
+
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/14](https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/14)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Based on the workflow's operations, it primarily interacts with repository contents (e.g., cloning, committing, and pushing changes). Therefore, we will set `contents: write` to allow these operations while restricting all other permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
