### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cross_ci.yml
+++ b/.github/workflows/cross_ci.yml
@@ -1,5 +1,8 @@
 name: Cross CI
 
+permissions:
+  contents: read
+
 on:
   push:
     paths-ignore:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/12](https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/12)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions` blocks. Based on the workflow's actions, the minimal required permission is `contents: read`, as the workflow primarily checks out code and performs builds and tests.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
