### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs_ci.yml
+++ b/.github/workflows/docs_ci.yml
@@ -1,4 +1,6 @@
 name: Docs CI
+permissions:
+  contents: read
 
 ### Run on *EVERY* .v or .md related commit.
 ### The documentation *SHOULD* stay valid, and the developers should receive


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/11](https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/11)

To fix the issue, we will add a `permissions` block at the root level of the workflow to apply minimal permissions to all jobs. Since the workflow only involves checking markdown files and reporting missing function documentation, it likely only requires `contents: read` permissions. This ensures that the `GITHUB_TOKEN` has the least privileges necessary to perform the tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
