### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/c2v_ci.yml
+++ b/.github/workflows/c2v_ci.yml
@@ -1,4 +1,6 @@
 name: C2V apps
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/8](https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/8)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the minimal permissions required for the workflow to function. Based on the workflow's steps, it primarily needs to read repository contents (`contents: read`). No write permissions are necessary, as the workflow does not modify repository contents or perform other actions requiring elevated privileges.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
