### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -2,6 +2,9 @@ name: Debug CI
 
 on: [workflow_dispatch]
 
+permissions:
+  contents: read
+
 jobs:
   debug-msvc:
     runs-on: windows-2019


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/4](https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Based on the workflow's steps, it appears that only `contents: read` is necessary, as the workflow primarily reads and builds code without modifying the repository or interacting with other GitHub features.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
