### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/bootstrapping_ci.yml
+++ b/.github/workflows/bootstrapping_ci.yml
@@ -1,5 +1,9 @@
 name: Bootstrapping CI
 
+permissions:
+  contents: read
+  actions: read
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/3](https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will define the minimum permissions required for the workflow to function correctly. Based on the workflow's operations:
- The `contents: read` permission is sufficient for most steps, as they involve building and testing code.
- The `actions: read` permission is required to fetch workflow runs using the GitHub API in the `Test v up` step.

The `permissions` block will be added at the root level, ensuring it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
