### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/benchmark_footprint_json_encode.yml
+++ b/.github/workflows/benchmark_footprint_json_encode.yml
@@ -8,6 +8,10 @@ on:
       - '!vlib/x/json2/strict/**' # Ignore
       - '!vlib/x/json2/tests/**' # Ignore
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   json-encode-benchmark:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/2](https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Based on the workflow's operations:
1. `contents: read` is needed to check out the repository.
2. `actions: read` is required to use the `actions/upload-artifact` action.

These permissions will be applied to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
