### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/benchmark_footprint_json_decode.yml
+++ b/.github/workflows/benchmark_footprint_json_decode.yml
@@ -1,5 +1,9 @@
 name: json decoder benchmark CI
 
+permissions:
+  contents: read
+  actions: read
+
 on:
   push:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/1](https://github.com/Git-Hub-Chris/Vlang/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the minimal permissions required. Based on the workflow's actions, it needs:
- `contents: read` to check out the repository.
- `actions: read` to use the `actions/upload-artifact` action.
- `contents: write` to upload the benchmark result file as an artifact.

The `permissions` block should be added at the top level of the workflow, ensuring it applies to all jobs unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
